### PR TITLE
Update deploy workflow to use 'docker compose' command syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,9 +59,9 @@ jobs:
           script: |
             set -e
             cd ~/quiz_application
-            docker-compose down || echo "No existing containers"
+            docker compose down || echo "No existing containers"
             docker pull ${{ secrets.DOCKER_USERNAME }}/quiz_application:latest
-            docker-compose --env-file .env.docker-compose up -d
+            docker compose --env-file .env.docker-compose up -d
 
             # Create data directory with correct permissions if it doesn't exist
             if [ ! -d "data" ]; then


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to align with the latest Docker command syntax by replacing `docker-compose` with `docker compose`.

Deployment workflow updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L62-R64): Replaced `docker-compose` commands with `docker compose` to use the updated Docker CLI syntax for managing containers.