### PR TITLE
Remove version specification from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   quiz-api:
     image: kuniquoc/quiz_application:latest


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file, updating the Docker Compose version to ensure compatibility with newer features.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1): Updated the Compose file version from `3.8` to the latest version.