### PR TITLE
Remove HTTPS port configuration from Docker setup and deployment files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,8 @@ jobs:
         run: |
           echo "DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}" > .env.docker-compose
           echo "PORT=5000" >> .env.docker-compose
-          echo "HTTPS_PORT=5001" >> .env.docker-compose
           echo "ASPNETCORE_ENVIRONMENT=Production" >> .env.docker-compose
-          echo "ASPNETCORE_URLS=http://+:5000;https://+:5001" >> .env.docker-compose
+          echo "ASPNETCORE_URLS=http://+:5000" >> .env.docker-compose
           echo "ConnectionStrings__DefaultConnection=Data Source=/app/data/quiz_application.db" >> .env.docker-compose
 
       - name: Copy files to Ubuntu server

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,9 @@ WORKDIR /app
 COPY --from=build /app/publish .
 
 # Set environment variables
-ENV ASPNETCORE_URLS=http://+:5000;https://+:5001
+ENV ASPNETCORE_URLS=http://+:5000
 ENV ASPNETCORE_ENVIRONMENT=Production
 
 EXPOSE 5000
-EXPOSE 5001
 
 ENTRYPOINT ["dotnet", "quiz_application.Api.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     restart: always
     ports:
       - "5000:5000"
-      - "5001:5001"
     volumes:
       - quiz-data:/app/data
     environment:


### PR DESCRIPTION
This pull request removes support for HTTPS on port 5001 in the application configuration. The changes simplify the setup by focusing solely on HTTP on port 5000.

### Removal of HTTPS support:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L39-R40): Removed the configuration for `HTTPS_PORT` and updated `ASPNETCORE_URLS` to exclude the HTTPS URL.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-L37): Removed the HTTPS URL from the `ASPNETCORE_URLS` environment variable and the exposure of port 5001.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L10): Removed the mapping for port 5001 in the `services` section.