### PR TITLE
Remove HTTPS configuration from application settings and default ports

### DIFF
--- a/quiz_application.Api/Program.cs
+++ b/quiz_application.Api/Program.cs
@@ -6,7 +6,7 @@ using quiz_application.Api.Middleware;
 var builder = WebApplication.CreateBuilder(args);
 
 // --- 0. Configure default ports ---
-builder.WebHost.UseUrls("http://localhost:5000", "https://localhost:5001");
+builder.WebHost.UseUrls("http://localhost:5000");
 
 // --- 1. Register Services into Dependency Injection container ---
 builder.Services.AddControllers();
@@ -29,11 +29,6 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-}
-else
-{
-    // Only use HTTPS redirection in production
-    app.UseHttpsRedirection();
 }
 
 // Global error handling middleware

--- a/quiz_application.Api/appsettings.json
+++ b/quiz_application.Api/appsettings.json
@@ -2,7 +2,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Data Source=quiz_application.db"
   },
-  "Urls": "http://localhost:5000;https://localhost:5001",
+  "Urls": "http://localhost:5000",
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
This pull request updates the `quiz_application.Api` to simplify the application's configuration by removing support for HTTPS and related settings. The changes focus on streamlining the application's development environment and reducing unnecessary complexity.

### Simplification of URL configuration:
* [`quiz_application.Api/Program.cs`](diffhunk://#diff-e7705bd06f15a0b165d37ec061965e29ef6b06ba1350d6ccaa354fe2bcc60093L9-R9): Removed the HTTPS URL (`https://localhost:5001`) from the `UseUrls` configuration, leaving only the HTTP URL (`http://localhost:5000`).
* [`quiz_application.Api/appsettings.json`](diffhunk://#diff-b448f5b33b5297b417c24b45aacdd7adc393daea523329f38d14b8ecf8220253L5-R5): Updated the `Urls` setting to remove the HTTPS URL (`https://localhost:5001`), retaining only the HTTP URL (`http://localhost:5000`).

### Removal of HTTPS redirection:
* [`quiz_application.Api/Program.cs`](diffhunk://#diff-e7705bd06f15a0b165d37ec061965e29ef6b06ba1350d6ccaa354fe2bcc60093L33-L37): Removed the conditional logic for enabling HTTPS redirection in production, as HTTPS support has been dropped.