### PR TITLE
Enable Swagger UI in all environments

### DIFF
--- a/quiz_application.Api/Program.cs
+++ b/quiz_application.Api/Program.cs
@@ -25,11 +25,8 @@ builder.Services.AddScoped<IQuizService, QuizService>();
 var app = builder.Build();
 
 // --- 3. Configure HTTP Request Pipeline (Middleware) ---
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+app.UseSwagger();
+app.UseSwaggerUI();
 
 // Global error handling middleware
 app.UseMiddleware<ErrorHandlingMiddleware>();


### PR DESCRIPTION
This pull request modifies the middleware configuration in `quiz_application.Api/Program.cs` to ensure the Swagger UI is always available, regardless of the environment.

* [`quiz_application.Api/Program.cs`](diffhunk://#diff-e7705bd06f15a0b165d37ec061965e29ef6b06ba1350d6ccaa354fe2bcc60093L28-L32): Removed the conditional check for `IsDevelopment()` when configuring Swagger and SwaggerUI, making them available in all environments.